### PR TITLE
Work-around some peculiarities of giskard and actionlib

### DIFF
--- a/src/cl-giskard.lisp
+++ b/src/cl-giskard.lisp
@@ -134,7 +134,7 @@
   (sb-thread:with-mutex (*feedback-mutex*)
     *left-arm-converged*))
 
-(defun left-arm-converged ()
+(defun right-arm-converged ()
   (sb-thread:with-mutex (*feedback-mutex*)
     *right-arm-converged*))
 


### PR DESCRIPTION
An actionlib-lisp client keeps spamming the done-cb once the :done state is reached. cl_giskard now cancels the goal (after the goal is reached) to prevent that.

Also, using the feedback-cb to update arm convergence flags, as it is more reliable. The giskard action server will never report :done until both arms have been given a goal, and both arms have reached their goal. If a goal is only given to one and the same arm always, :done is never reported.
